### PR TITLE
Updated docker version check

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -84,7 +84,8 @@ echo
 # Check docker enging version.
 dockerverone=$(docker version -f='{{ .Client.Version }}' | awk -F[=.] '{print $1}')
 dockervertwo=$(docker version -f='{{ .Client.Version }}' | awk -F[=.] '{print $2}')
-if [ $dockerverone -eq $DOCKER_MAJOR_VER ] && [ $dockervertwo -ge $DOCKER_MINOR_VER ]; then
+#if [ $dockerverone -eq $DOCKER_MAJOR_VER ] && [ $dockervertwo -ge $DOCKER_MINOR_VER ]; then
+if [ $dockerverone -gt $DOCKER_MAJOR_VER  ] || ([ $dockerverone -eq $DOCKER_MAJOR_VER  ] && [ $dockervertwo -ge $DOCKER_MINOR_VER ]) ; then
 	echo "Valid version of docker engine found... $dockerverone.$dockervertwo"
 	echo
 else


### PR DESCRIPTION
Checking docker by major and minor version independently fails. Lets say 17.03 is the current version, major version 17 is > 1, but the minor version 03 !> 10 and hence it fails though 17.10 is clearly > 1.10