### PR TITLE
Make alterations to init.sh to install on Linux

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -8,7 +8,13 @@ OC_MINI_VER=5
 OCP_VERSION="$OC_MAJOR_VER.$OC_MINOR_VER"
 
 # sets RAM usage limit for OCP.
-VBOX_MEMORY=12288
+VM_MEMORY=12288
+
+if [ `uname` == 'Linux' ]; then
+		virt_driver='kvm'
+else
+		virt_driver='virtualbox'
+fi
 
 # wipe screen.
 clear 
@@ -47,13 +53,24 @@ if [ `uname` == 'Darwin' ]; then
 		command -v VirtualBox -h >/dev/null 2>&1 || { echo >&2 "VirtualBox is required but not installed yet... download here: https://www.virtualbox.org/wiki/Downloads"; exit 1; }
 		echo "VirtualBox is installed..."
 		echo
+elif [ `uname` == 'Linux' ]; then
+    echo "You are running on Linux."
+    echo "This script assumes you are going to use KVM on Linux."
+    echo "You'll need to install docker-machine and docker-machine-driver-kvm in your \$PATH manually."
+    echo "Download them from https://github.com/docker/machine/releases and https://github.com/dhiltgen/docker-machine-kvm/releases, respectively."
 fi
 
 # Ensure docker engine available.
 #
-command -v docker -h  >/dev/null 2>&1 || { echo >&2 "Docker is required but not installed yet... download here: https://store.docker.com/search?offering=community&type=edition"; exit 1; }
-echo "Docker is installed... checking for valid version..."
-echo
+if [ `uname` == 'Darwin' ]; then
+		command -v docker -h  >/dev/null 2>&1 || { echo >&2 "Docker is required but not installed yet... download here: https://store.docker.com/search?offering=community&type=edition"; exit 1; }
+		echo "Docker is installed... checking for valid version..."
+		echo
+elif [ `uname` == 'Linux' ]; then
+		command -v docker -h  >/dev/null 2>&1 || { echo >&2 "Docker is required but not installed yet... download here: https://store.docker.com/search?offering=community&type=edition or install through your distro's package manager"; exit 1; }
+		echo "Docker is installed... checking for valid version..."
+		echo
+fi
 
 # Check that docker deamon is setup correctly.
 if [ `uname` == 'Darwin' ]; then
@@ -66,8 +83,8 @@ if [ `uname` == 'Darwin' ]; then
 		exit
 	fi
 else
-	# for Linux versions.
-	docker ps >/dev/null 2>&1
+	# for Linux versions; at least on Fedora, docker needs root permissions
+	sudo docker ps >/dev/null 2>&1
 
 	if [ $? -ne 0 ]; then
 		echo "Docker deamon is not running... or is running insecurely..."
@@ -82,15 +99,22 @@ echo "Verified the Docker deamon is running..."
 echo
 
 # Check docker enging version.
-dockerverone=$(docker version -f='{{ .Client.Version }}' | awk -F[=.] '{print $1}')
-dockervertwo=$(docker version -f='{{ .Client.Version }}' | awk -F[=.] '{print $2}')
-if [ $dockerverone -eq $DOCKER_MAJOR_VER ] && [ $dockervertwo -ge $DOCKER_MINOR_VER ]; then
-	echo "Valid version of docker engine found... $dockerverone.$dockervertwo"
-	echo
-else
-	echo "Docker engine version $dockerverone.$dockervertwo found... need $DOCKER_MAJOR_VER.$DOCKER_MINOR_VER or higher, please install: https://store.docker.com/search?offering=community&type=edition"
-	echo
-	exit
+if [ `uname` == 'Darwin' ]; then
+		dockerverone=$(docker version -f='{{ .Client.Version }}' | awk -F[=.] '{print $1}')
+		dockervertwo=$(docker version -f='{{ .Client.Version }}' | awk -F[=.] '{print $2}')
+		if [ $dockerverone -eq $DOCKER_MAJOR_VER ] && [ $dockervertwo -ge $DOCKER_MINOR_VER ]; then
+			echo "Valid version of docker engine found... $dockerverone.$dockervertwo"
+			echo
+		else
+			echo "Docker engine version $dockerverone.$dockervertwo found... need $DOCKER_MAJOR_VER.$DOCKER_MINOR_VER or higher, please install: https://store.docker.com/search?offering=community&type=edition"
+			echo
+			exit
+		fi
+elif [ `uname` == 'Linux' ]; then
+		echo "This demo has been tested with docker 1.12 as shipped with Fedora."
+		echo "As various distro's ship with different versions of docker, not all available docker versions have been tested."
+		echo "As such, the demo probably works with other versions of docker installed locally, but ymmv."
+        echo
 fi
 
 # Ensure OpenShift command line tools available.
@@ -123,7 +147,7 @@ fi
 
 echo "Setting up OpenShift docker machine..."
 echo
-docker-machine create --driver virtualbox --virtualbox-cpu-count "2" --virtualbox-memory "$VBOX_MEMORY" --engine-insecure-registry 172.30.0.0/16  --virtualbox-boot2docker-url https://github.com/boot2docker/boot2docker/releases/download/v1.13.1/boot2docker.iso openshift 
+docker-machine create --driver ${virt_driver} --${virt_driver}-cpu-count "2" --${virt_driver}-memory "$VM_MEMORY" --engine-insecure-registry 172.30.0.0/16  --${virt_driver}-boot2docker-url https://github.com/boot2docker/boot2docker/releases/download/v1.13.1/boot2docker.iso openshift 
 
 if [ $? -ne 0 ]; then
 		echo
@@ -135,7 +159,7 @@ if [ $? -ne 0 ]; then
 
 		echo "Setting up new OpenShift docker machine..."
     echo
-    docker-machine create --driver virtualbox --virtualbox-cpu-count "2" --virtualbox-memory "$VBOX_MEMORY" --engine-insecure-registry 172.30.0.0/16 --virtualbox-boot2docker-url https://github.com/boot2docker/boot2docker/releases/download/v1.13.1/boot2docker.iso openshift 
+    docker-machine create --driver ${virt_driver} --${virt_driver}-cpu-count "2" --${virt_driver}-memory "$VM_MEMORY" --engine-insecure-registry 172.30.0.0/16 --${virt_driver}-boot2docker-url https://github.com/boot2docker/boot2docker/releases/download/v1.13.1/boot2docker.iso openshift 
 
 		if [ $? -ne 0 ]; then
 				echo
@@ -162,7 +186,7 @@ if [ $? -ne 0 ]; then
 
     echo "Setting up new OpenShift docker machine..."
     echo
-    docker-machine create --driver virtualbox --virtualbox-cpu-count "2" --virtualbox-memory "$VBOX_MEMORY" --engine-insecure-registry 172.30.0.0/16 --virtualbox-boot2docker-url https://github.com/boot2docker/boot2docker/releases/download/v1.13.1/boot2docker.iso openshift 
+    docker-machine create --driver ${virt_driver} --${virt_driver}-cpu-count "2" --${virt_driver}-memory "$VM_MEMORY" --engine-insecure-registry 172.30.0.0/16 --${virt_driver}-boot2docker-url https://github.com/boot2docker/boot2docker/releases/download/v1.13.1/boot2docker.iso openshift 
 
 		echo
 		echo "Trying again to install OCP with cluster up..."


### PR DESCRIPTION
Previously this script was a bit biased towards Windows and Mac systems
running Virtualbox.

This patch adds some provisions to deploy the OCP on Linux machines as
well. Patch was written and tested on Fedora 25, but I don't see any
reason why it shouldn't work on any other flavor of Linux.

It adds a variable to choose the right docker-machine driver on Linux
(docker-machine-driver-kvm), but assumes the user has installed that
driver manually.

I'm assuming the average Linux user installs docker through the
distribution's package manager rather than downloading it directly from
the Docker website. This is why I have removed the version check for
docker on Linux. For docker as shipped with Fedora 25 (1.12), it works
fine.

One thing that is a bit tricky, is that on Fedora, CentOS and RHEL, we
only allow root to run the docker command. Hence, I added 'sudo' in
front of the 'docker ps' test. This does assume your account can execute
docker as root.

If other distributions have other provisions for this (i.e. something
like a group that is allowed to run docker without sudo, or similar),
the sudo command might not be necessary and even a bit intrusive.
Haven't tested that though.